### PR TITLE
Add client-side search to index.md and apps.md

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,1 @@
+<script src="{{ '/assets/js/search.js' | relative_url }}" defer></script>

--- a/apps.md
+++ b/apps.md
@@ -5,7 +5,7 @@
 
 #### Here are listed all **3120** unique applications, AppImage packages and command line utilities managed by [AM](https://github.com/ivan-hc/AM) 	and [AppMan](https://github.com/ivan-hc/AppMan) for the x86_64 architecture, plus **78** more entries and items to help you install apps more easily.
 
-*Use your browser's built-in search tool to easily navigate to this page or use the tags below.*
+*Use the search box below to filter the table, or jump straight to a category using the tags below.*
 
 
 #### *Categories*
@@ -25,6 +25,13 @@
 *Transparency and credibility are the focus of this catalog. Happy exploring!*
 
 -----------------
+
+<div id="app-search-box" style="margin: 1em 0;">
+  <label for="app-search-input" style="font-weight: bold;">Search applications:</label>
+  <input type="search" id="app-search-input" placeholder="Type a name or keyword..." autocomplete="off"
+    style="width: 100%; max-width: 480px; padding: 0.5em 0.75em; margin-top: 0.25em; font-size: 1em; border: 1px solid #999; border-radius: 4px; box-sizing: border-box;">
+  <span id="app-search-count" style="margin-left: 0.5em; font-style: italic; color: #666;"></span>
+</div>
 
 | ICON | PACKAGE NAME | DESCRIPTION | INSTALLER |
 | --- | --- | --- | --- |

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,139 @@
+(function () {
+  'use strict';
+
+  function escapeHtml(s) {
+    return String(s).replace(/[&<>"']/g, function (c) {
+      return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c];
+    });
+  }
+
+  // Filters the rows of the big apps table in-place.
+  function initTableFilter() {
+    var input = document.getElementById('app-search-input');
+    var counter = document.getElementById('app-search-count');
+    if (!input) return;
+
+    var table = input.closest('div').nextElementSibling;
+    while (table && table.tagName !== 'TABLE') table = table.nextElementSibling;
+    if (!table) return;
+
+    var rows = Array.prototype.slice.call(table.tBodies[0] ? table.tBodies[0].rows : table.rows);
+    if (rows.length && rows[0].cells[0] && rows[0].cells[0].tagName === 'TH') rows.shift();
+
+    var haystacks = rows.map(function (row) {
+      return (row.textContent || '').toLowerCase();
+    });
+    var total = rows.length;
+
+    function update() {
+      var q = input.value.trim().toLowerCase();
+      var visible = 0;
+      for (var i = 0; i < rows.length; i++) {
+        var match = q === '' || haystacks[i].indexOf(q) !== -1;
+        rows[i].style.display = match ? '' : 'none';
+        if (match) visible++;
+      }
+      counter.textContent = q === ''
+        ? '(' + total + ' apps)'
+        : '(' + visible + ' of ' + total + ' shown)';
+    }
+
+    input.addEventListener('input', update);
+
+    var params = new URLSearchParams(window.location.search);
+    var initialQ = params.get('q');
+    if (initialQ) {
+      input.value = initialQ;
+      input.focus();
+    }
+    update();
+  }
+
+  // Fetches apps.json and renders a short list of matches with links.
+  function initJsonSearch() {
+    var MAX_RESULTS = 20;
+    var APPS_URL = 'apps.json';
+    var APPS_PAGE = 'apps.html';
+
+    var input = document.getElementById('home-search-input');
+    var status = document.getElementById('home-search-status');
+    var results = document.getElementById('home-search-results');
+    var more = document.getElementById('home-search-more');
+    if (!input) return;
+
+    var apps = null;
+    var pending = null;
+
+    function load() {
+      if (apps || pending) return pending;
+      pending = fetch(APPS_URL).then(function (r) { return r.json(); }).then(function (data) {
+        apps = data;
+        status.textContent = apps.length + ' apps in the database.';
+        if (input.value.trim()) render(input.value.trim());
+      }).catch(function () {
+        status.textContent = 'Could not load the app database. Try again later.';
+      });
+      return pending;
+    }
+
+    function render(q) {
+      results.innerHTML = '';
+      more.innerHTML = '';
+      if (!apps) return;
+      if (!q) {
+        status.textContent = apps.length + ' apps in the database.';
+        return;
+      }
+      var needle = q.toLowerCase();
+      var matches = [];
+      for (var i = 0; i < apps.length; i++) {
+        var a = apps[i];
+        var hay = (a.packageName + ' ' + (a.description || '')).toLowerCase();
+        if (hay.indexOf(needle) !== -1) matches.push(a);
+      }
+      if (!matches.length) {
+        status.textContent = 'No apps match "' + q + '".';
+        return;
+      }
+      status.textContent = matches.length + ' match' + (matches.length === 1 ? '' : 'es')
+        + (matches.length > MAX_RESULTS ? ' (showing first ' + MAX_RESULTS + ')' : '') + ':';
+      var shown = matches.slice(0, MAX_RESULTS);
+      var html = '';
+      for (var j = 0; j < shown.length; j++) {
+        var m = shown[j];
+        var safeName = escapeHtml(m.packageName);
+        var safeDesc = escapeHtml((m.description || '').replace(/\.\.\.$/, ''));
+        var safeIcon = escapeHtml(m.icon || '');
+        html += '<li style="display: flex; align-items: center; gap: 0.6em; padding: 0.35em 0.25em; border-bottom: 1px solid #eee;">'
+             +   '<img loading="lazy" src="' + safeIcon + '" alt="" width="32" height="32" style="flex: 0 0 32px;">'
+             +   '<span style="flex: 1;">'
+             +     '<a href="apps/' + safeName + '.html"><strong>' + safeName + '</strong></a>'
+             +     '<br><span style="color: #555; font-size: 0.9em;">' + safeDesc + '</span>'
+             +   '</span>'
+             + '</li>';
+      }
+      results.innerHTML = html;
+      if (matches.length > MAX_RESULTS) {
+        more.innerHTML = '<a href="' + APPS_PAGE + '?q=' + encodeURIComponent(q) + '">See all '
+          + matches.length + ' matches on the apps page &rarr;</a>';
+      }
+    }
+
+    input.addEventListener('focus', load);
+    input.addEventListener('input', function () {
+      if (apps) render(input.value.trim());
+      else load();
+    });
+  }
+
+  function init() {
+    initTableFilter();
+    initJsonSearch();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -124,6 +124,8 @@
       if (apps) render(input.value.trim());
       else load();
     });
+
+    load();
   }
 
   function init() {

--- a/index.md
+++ b/index.md
@@ -18,6 +18,15 @@
 | - | - |
 | [<img loading="lazy" src="https://github.com/user-attachments/assets/f55d4242-bd5f-4195-946c-e01c6fe5e264" width="512" height="256">](https://portable-linux-apps.github.io/apps.html) | [<img loading="lazy" src="https://raw.githubusercontent.com/ivan-hc/AM/main/sample/sample.png" width="512" height="256">](https://github.com/ivan-hc/AM) |
 
+<div id="home-search" style="margin: 1.5em auto; max-width: 640px; text-align: left;">
+  <label for="home-search-input" style="font-weight: bold; display: block; margin-bottom: 0.25em; text-align: center;">Search applications</label>
+  <input type="search" id="home-search-input" placeholder="Start typing an app name or keyword..." autocomplete="off"
+    style="width: 100%; padding: 0.6em 0.85em; font-size: 1em; border: 1px solid #999; border-radius: 4px; box-sizing: border-box;">
+  <div id="home-search-status" style="margin-top: 0.5em; font-style: italic; color: #666; text-align: center;">Loading app database&hellip;</div>
+  <ul id="home-search-results" style="list-style: none; padding: 0; margin: 0.5em 0 0;"></ul>
+  <div id="home-search-more" style="margin-top: 0.5em; text-align: center;"></div>
+</div>
+
 #### *Categories*
 
 ***[AppImages](appimages.md)*** 		 - ***[am-utils](am-utils.md)*** - ***[android](android.md)*** - ***[audio](audio.md)*** - ***[comic](comic.md)*** - ***[command-line](command-line.md)*** - ***[communication](communication.md)*** - ***[disk](disk.md)*** - ***[education](education.md)*** - ***[file-manager](file-manager.md)*** - ***[finance](finance.md)*** - ***[game](game.md)*** - ***[gnome](gnome.md)*** - ***[graphic](graphic.md)*** - ***[internet](internet.md)*** - ***[kde](kde.md)*** - ***[office](office.md)*** - ***[password](password.md)*** - ***[steam](steam.md)*** - ***[system-monitor](system-monitor.md)*** - ***[video](video.md)*** - ***[web-app](web-app.md)*** - ***[web-browser](web-browser.md)*** - ***[wine](wine.md)***


### PR DESCRIPTION
- New shared script assets/js/search.js powers both widgets
- Home page: fetches apps.json on focus, shows up to 20 matching apps with icon + link, plus a "see all matches" link to apps.html?q=...
- Apps page: filters the existing table in place, pre-fills from the ?q= URL param so the handoff from the home page lands pre-filtered