### PR TITLE
Rank search results by relevance instead of alphabetical order

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -197,6 +197,7 @@ section h2 {
   border: 1px solid var(--color-border);
   border-radius: var(--radius);
   overflow: hidden;
+  margin-top: 1rem;
 }
 
 .app-item {
@@ -217,6 +218,17 @@ section h2 {
   box-shadow: 4px 4px 12px rgba(0, 0, 0, 0.35);
   background: var(--color-surface);
   z-index: 1;
+}
+
+.app-group-heading {
+  padding: 0.5rem 0.75rem;
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: 1px solid var(--color-border);
 }
 
 /* Categories */

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -96,9 +96,25 @@ document.addEventListener('DOMContentLoaded', function() {
         }
       }
 
+      // Relevance rank: 0 exact name, 1 name starts with, 2 name contains, 3 description only.
+      var RANK_LABELS = ['Exact match', 'Name match', 'Name match', 'Description match'];
+
+      function matchRank(k, terms) {
+        var name = cache[k].name;
+        if (terms.length === 1 && name === terms[0]) return 0;
+        var nameHit = terms.every(function(t) { return name.indexOf(t) !== -1; });
+        if (!nameHit) return 3;
+        return name.indexOf(terms[0]) === 0 ? 1 : 2;
+      }
+
       function applyFilters() {
         var terms = input ? input.value.toLowerCase().split(/\s+/).filter(Boolean) : [];
         var selectedArch = arch ? arch.value : '';
+        var list = document.getElementById('app-list').querySelector('.app-list');
+        var matched = [];
+
+        var oldHeadings = list.querySelectorAll('.app-group-heading');
+        for (var h = 0; h < oldHeadings.length; h++) oldHeadings[h].remove();
 
         for (var k = 0; k < appNodes.length; k++) {
           var matchesSearch = !terms.length ||
@@ -108,7 +124,31 @@ document.addEventListener('DOMContentLoaded', function() {
             });
           var matchesArch = !selectedArch ||
             cache[k].archs.some(function(a) { return a === selectedArch; });
-          appNodes[k].style.display = (matchesSearch && matchesArch) ? '' : 'none';
+          var visible = matchesSearch && matchesArch;
+          appNodes[k].style.display = visible ? '' : 'none';
+          if (visible) matched.push({ index: k, rank: terms.length ? matchRank(k, terms) : 0 });
+        }
+
+        if (terms.length) {
+          matched.sort(function(a, b) {
+            return a.rank !== b.rank ? a.rank - b.rank : cache[a.index].name.localeCompare(cache[b.index].name);
+          });
+        }
+
+        var lastLabel = null;
+        for (var m = 0; m < matched.length; m++) {
+          var entry = matched[m];
+          if (terms.length) {
+            var label = RANK_LABELS[entry.rank];
+            if (label !== lastLabel) {
+              var heading = document.createElement('div');
+              heading.className = 'app-group-heading';
+              heading.textContent = label;
+              list.appendChild(heading);
+              lastLabel = label;
+            }
+          }
+          list.appendChild(appNodes[entry.index]);
         }
       }
 


### PR DESCRIPTION
Search matched against both name and description, but results stayed in alphabetical order. Searching for "zed" produced a long list of unrelated apps matched via description, with `zed` itself buried near the end.

Now results are ranked: exact name match first, then name-starts-with, then name-contains, then description-only matches — with a heading separating each group. Matching by name first felt like the more useful default.

**Examples:**

<img width="1191" height="1312" alt="Screenshot_20260901_194502" src="https://github.com/user-attachments/assets/62047fd0-7fe4-4db1-b549-0720abd8bb8c" />
<br/><br/><br/>
<img width="1191" height="1312" alt="Screenshot_20260901_194524" src="https://github.com/user-attachments/assets/fec6f6c9-43e5-441f-a057-39876ca53e08" />
<br/><br/><br/>
<img width="1191" height="1312" alt="Screenshot_20260901_194545" src="https://github.com/user-attachments/assets/17179afb-6c38-4c2c-8c92-012b6c26bdbb" />

